### PR TITLE
Calculate Gbps in plot.py.

### DIFF
--- a/autotrex/benchmark.py
+++ b/autotrex/benchmark.py
@@ -24,7 +24,6 @@ def single_run(c, profile, mult, pkt_size):
     total = s["total"]
     tx_pkts = total["opackets"]
     rx_pkts = total["ipackets"]
-    bps = total["tx_bps"]
     pps = total["tx_pps"]
 
     lossrate = max(0.0, (1 - rx_pkts / tx_pkts)) * 100.0  # percent
@@ -37,7 +36,6 @@ def single_run(c, profile, mult, pkt_size):
         "pkt_size": pkt_size,
         "mult_pct": mult,
         "lossrate_pct": lossrate,
-        "bps": bps,
         "pps": pps,
         "tx_pkts": tx_pkts,
         "rx_pkts": rx_pkts,
@@ -90,16 +88,14 @@ def main():
     finally:
         c.disconnect()
 
-    Gbpss = []
     Mppss = []
-    print("pkt_size", "bps", "pps")
+    print("pkt_size", "pps")
     for pkt_size, result in results.items():
-        print(pkt_size, result['bps'], result['pps'])
+        print(pkt_size, result['pps'])
         # Not use 2^N. use 10^N in networking.
-        Gbpss.append(result['bps'] / 1e9)
         Mppss.append(result['pps'] / 1e6)
 
-    plot_Gbps(pkt_sizes, Gbpss, link_speed_bps)
+    plot_Gbps(pkt_sizes, Mppss, link_speed_bps)
     plot_Mpps(pkt_sizes, Mppss, link_speed_bps)
 
 

--- a/autotrex/plot.py
+++ b/autotrex/plot.py
@@ -1,10 +1,16 @@
 import matplotlib.pyplot as plt
 
 
-def plot_Gbps(packet_sizes, Gbpss, link_speed_bps):
+def plot_Gbps(packet_sizes, Mppss, link_speed_bps):
     X = packet_sizes
-    Y = Gbpss
+    Y = []
     Y_max = []
+
+    # Calc actual throuput.
+    for i, pkt_size in enumerate(packet_sizes):
+        Mbps = pkt_size * Mppss[i] * 8
+        Gbps = Mbps / 1e3
+        Y.append(Gbps)
 
     # Calc theoretical maximum throuput.
     for pkt_size in packet_sizes:
@@ -68,15 +74,6 @@ if __name__ == '__main__':
     pkt_sizes = [1518, 1280, 1024, 512, 256, 128, 64]
 
     # Example Data.
-    Gbpss = [
-        9.78141696,
-        9.85044582,
-        8.60178022,
-        4.78739148,
-        2.43599206,
-        1.24389184,
-        0.61393779,
-    ]
     Mppss = [
         0.805452,
         0.961957,
@@ -86,5 +83,5 @@ if __name__ == '__main__':
         1.214738,
         1.199097,
     ]
-    plot_Gbps(pkt_sizes, Gbpss, 10*1e9)
+    plot_Gbps(pkt_sizes, Mppss, 10*1e9)
     plot_Mpps(pkt_sizes, Mppss, 10*1e9)


### PR DESCRIPTION
### this branch.
```
plot_Gbps:
packet_size, actual, theoretical
64, 0.6126425600000001, 7.619047619047619
128, 1.215721984, 8.64864864864865
256, 2.3889331200000004, 9.27536231884058
512, 4.474966016000001, 9.624060150375941
1024, 7.933208576, 9.808429118773947
1280, 9.10652032, 9.846153846153847
1518, 9.094577844000002, 9.869960988296487
plot_Mpps:
packet_size, actual, theoretical
64, 1.1965675, 14.880952380952381
128, 1.1872285, 8.445945945945947
256, 1.16647125, 4.528985507246377
512, 1.092521, 2.349624060150376
1024, 0.96840925, 1.1973180076628354
1280, 0.889308625, 0.9615384615384615
1518, 0.74889475, 0.812743823146944
```

### main barnch

```
plot_Gbps:
packet_size, actual, theoretical
64, 0.591170304, 7.619047619047619
128, 1.166348032, 8.64864864864865
256, 2.236132096, 9.27536231884058
512, 4.454569984, 9.624060150375941
1024, 8.108748288, 9.808429118773947
1280, 9.214567424, 9.846153846153847
1518, 9.31700736, 9.869960988296487
plot_Mpps:
packet_size, actual, theoretical
64, 1.1546295, 14.880952380952381
128, 1.139011875, 8.445945945945947
256, 1.09186125, 4.528985507246377
512, 1.087502875, 2.349624060150376
1024, 0.9892663125, 1.1973180076628354
1280, 0.8992859375, 0.9615384615384615
1518, 0.76721075, 0.812743823146944
```